### PR TITLE
Fix warnings in RepeatController on setTimeZone

### DIFF
--- a/src/Controller/RepeatController.php
+++ b/src/Controller/RepeatController.php
@@ -327,10 +327,10 @@ class RepeatController extends ControllerBase {
       // Convert timezones for start_time and end_time.
       $time_start = new \DateTime();
       $time_start->setTimestamp($item->start_timestamp);
-      $time_start->setTimezone(date_default_timezone_get());
+      $time_start->setTimezone(new \DateTimeZone(date_default_timezone_get()));
       $time_end = new \DateTime();
       $time_end->setTimestamp($item->end_timestamp);
-      $time_end->setTimezone(date_default_timezone_get());
+      $time_end->setTimezone(new \DateTimeZone(date_default_timezone_get()));
       $result[$key]->time_start = $time_start->format('g:iA');
       $result[$key]->time_end = $time_end->format('g:iA');
 


### PR DESCRIPTION
# How to review
https://jet-dev.atlassian.net/browse/RGTC-1623
- [ ] Go to` /y-schedules` you should see schedules as expected, you should not see any warnings in logs like this:
![image](https://user-images.githubusercontent.com/26228931/112816550-33919e80-908a-11eb-957a-f67f992f6536.png)
