### PR TITLE
[MAINTAIN-176] Fix broken schedules

### DIFF
--- a/templates/openy-repeat-schedule-dashboard--table.html.twig
+++ b/templates/openy-repeat-schedule-dashboard--table.html.twig
@@ -33,7 +33,7 @@
     <div class="vue-template">
 
       <div class="schedules-data clearfix">
-        <div v-for="(item, index) in propData" class="schedules-data__row">
+        <div v-for="(item, index) in propData" class="schedules-data__row" :key="index">
           <div class="col-xs-3 col-md-2 col-sm-2">
             {# time #}
             <div class="time-column" v-cloak>


### PR DESCRIPTION
This PR is going to fix the broken schedules when on schedules present more than one entry (different time paragraphs) of the same node.

Before: https://i.imgur.com/2o7VZK1.png
After: https://i.imgur.com/Mkoqi2i.png

Steps for review (on any theme except carnation):
- [ ] visit schedules page and choose any session
- [ ] visit edit page of this session
- [ ] add a new time paragraph with the same days https://i.imgur.com/5DxRECL.png -> save session
- [ ] visit schedules page again and make sure schedules app works fine (try to apply different filters, change date ...) 
