### PR TITLE
[MAINTAIN-176] Fix location popup for camps and facilities.

### DIFF
--- a/src/Controller/RepeatController.php
+++ b/src/Controller/RepeatController.php
@@ -356,7 +356,7 @@ class RepeatController extends ControllerBase {
   }
 
   /**
-   * Get detailed info about Location (aka branch).
+   * Get detailed info about Location (aka branch), camps, facilities.
    */
   public function getLocationsInfo() {
     $data = [];
@@ -369,7 +369,7 @@ class RepeatController extends ControllerBase {
       $nids = $this->entityTypeManager
         ->getStorage('node')
         ->getQuery()
-        ->condition('type', ['branch', 'location', 'camp'], 'IN')
+        ->condition('type', ['branch', 'location', 'camp', 'facility'], 'IN')
         ->execute();
       $nids_chunked = array_chunk($nids, 20, TRUE);
       foreach ($nids_chunked as $chunk) {

--- a/src/Controller/RepeatController.php
+++ b/src/Controller/RepeatController.php
@@ -369,7 +369,7 @@ class RepeatController extends ControllerBase {
       $nids = $this->entityTypeManager
         ->getStorage('node')
         ->getQuery()
-        ->condition('type', ['branch', 'location'], 'IN')
+        ->condition('type', ['branch', 'location', 'camp'], 'IN')
         ->execute();
       $nids_chunked = array_chunk($nids, 20, TRUE);
       foreach ($nids_chunked as $chunk) {
@@ -377,7 +377,8 @@ class RepeatController extends ControllerBase {
         if (!empty($branches)) {
           /** @var Node $node */
           foreach ($branches as $node) {
-            $days = $node->get('field_branch_hours')->getValue();
+            $days = $node->hasField('field_branch_hours') ?
+              $node->get('field_branch_hours')->getValue() : [];
             $address = $node->get('field_location_address')->getValue();
             if (!empty($address[0])) {
               $address = array_filter($address[0]);

--- a/templates/openy-repeat-schedule-dashboard--table.html.twig
+++ b/templates/openy-repeat-schedule-dashboard--table.html.twig
@@ -212,7 +212,7 @@
               <td><label>{{ 'Email'|t }}</label></td>
               <td><a v-bind:href="'mailto:' + locationPopup.email">${ locationPopup.email }</a></td>
             </tr>
-            <tr>
+            <tr v-if="locationPopup.days && locationPopup.days.length > 0">
               <td><label>{{ 'Branch hours'|t }}</label></td>
               <td>
                 <table class="table">


### PR DESCRIPTION
Steps for review:
- [ ] find or create camp
- [ ] open schedules page
- [ ] choose some session in schedules and find it on content listing /admin/content -> visit edit page
- [ ] In Location field set previously found camp -> save session
- [ ] reload schedules
- [ ] make sure camp name displayed in location column https://i.imgur.com/0quBH7C.png
- [ ] click on the title -> make sure popup appears -> close popup
- [ ] make sure app (filters, pagination etc) works fine

Repeat the same steps for the Facility content type.