### PR TITLE
Deal with nolink or none routes on register url.

### DIFF
--- a/templates/openy-repeat-schedule-dashboard--table.html.twig
+++ b/templates/openy-repeat-schedule-dashboard--table.html.twig
@@ -124,7 +124,8 @@
                   </template>
                   <template v-else>
                     <div v-cloak class="register-column" v-if="item.register_url">
-                      <a v-bind:href="item.register_url" class="btn btn-primary register-btn">${ item.register_text }</a>
+                      <a v-if="item.register_url == 'route:<nolink>' || item.register_url == 'route:<none>'" class="btn btn-primary disabled register-btn">${ item.register_text }</a>
+                      <a v-else v-bind:href="item.register_url" class="btn btn-primary register-btn">${ item.register_text }</a>
                     </div>
                   </template>
                 </div>
@@ -344,7 +345,8 @@
                   </template>
                   <template v-else>
                     <div v-cloak class="register-column" v-if="item.register_url">
-                      <a v-bind:href="item.register_url" class="btn btn-primary register-btn">${ item.register_text }</a>
+                      <a v-if="item.register_url == 'route:<nolink>' || item.register_url == 'route:<none>'" class="btn btn-primary disabled register-btn">${ item.register_text }</a>
+                      <a v-else v-bind:href="item.register_url" class="btn btn-primary register-btn">${ item.register_text }</a>
                     </div>
                   </template>
                 </div>
@@ -482,7 +484,8 @@
                   </template>
                   <template v-else>
                     <div v-cloak class="register-column" v-if="item.register_url">
-                      <a v-bind:href="item.register_url" class="btn btn-primary register-btn">${ item.register_text }</a>
+                      <a v-if="item.register_url == 'route:<nolink>' || item.register_url == 'route:<none>'" class="btn btn-primary disabled register-btn">${ item.register_text }</a>
+                      <a v-else v-bind:href="item.register_url" class="btn btn-primary register-btn">${ item.register_text }</a>
                     </div>
                   </template>
                 </div>


### PR DESCRIPTION
Drupal allows empty links to be made with `<nolink>` or `<none>` in the link field URI text. We should handle this, otherwise the url appears as `href="route:<nolink>"`.

Fixes #20 

To test:
- Set the `uri` value of a Session item to `<none>` or `<nolink>`
- Observe the front-end displays a disabled button instead of a broken link.