### PR TITLE
Handle deleted referenced entity situations

### DIFF
--- a/src/Plugin/Field/FieldFormatter/JsonFormatter.php
+++ b/src/Plugin/Field/FieldFormatter/JsonFormatter.php
@@ -41,7 +41,7 @@ class JsonFormatter extends FormatterBase {
 
     $export = [];
     foreach ($items as $item) {
-      if ($item instanceof EntityReferenceItem) {
+      if ($item instanceof EntityReferenceItem && $item->entity) {
         $export[] = [
           'id' => $item->entity->id(),
           'title' => $item->entity->label(),


### PR DESCRIPTION
In case a referenced entity is deleted, the calls to `$item->entity->method()` will fail with the message "Call to a member function method() on null" (line 46)