### PR TITLE
Fix filter by Rooms for PDF version

### DIFF
--- a/src/Controller/RepeatController.php
+++ b/src/Controller/RepeatController.php
@@ -551,7 +551,7 @@ class RepeatController extends ControllerBase {
       $timestamp_start += 86400;
     }
     if (!empty($rooms)) {
-      $rooms = explode(',', $rooms);
+      $rooms = explode(';', $rooms);
     }
     // Group by activity.
     if ($mode == 'activity') {


### PR DESCRIPTION
Semicolon [is used in JS](https://github.com/ynorth-projects/openy_repeat/blob/9.x-2.x/js/repeat/src/repeat.js#L702) but comma is used on the back-end

Steps for review:
* Go to Schedule
* Filter results by a location and room
* Verify the PDF version works fine