### PR TITLE
fix: TypeError: in_array(): Argument #2 ($haystack) must be of type a…

### DIFF
--- a/src/Controller/RepeatController.php
+++ b/src/Controller/RepeatController.php
@@ -580,6 +580,9 @@ class RepeatController extends ControllerBase {
       return FALSE;
     }
     $date_keys = $formatted_result = [];
+    if (!is_array($classnames) && $classnames) {
+      $classnames = [$classnames];
+    }
 
     // Create weekdays array.
     foreach ($result as $day => $data) {


### PR DESCRIPTION
…rray, string given in in_array()

Fixes: ```TypeError: in_array(): Argument #2 ($haystack) must be of type array, string given in in_array() (line 616 of /srv/www/ygtc_github/releases/20220829084716/docroot/modules/contrib/openy_repeat/src/Controller/RepeatController.php) #0 /srv/www/ygtc_github/releases/20220829084716/docroot/modules/contrib/openy_repeat/src/Controller/RepeatController.php(616): in_array('Northeast Adult...', 'Conditioning To...')```


See https://metrics.ymcanorth.org/d/iw_UUgi7z/drupal?orgId=1&refresh=1m&var-hostname=All&var-type=All&var-base_url=All&var-severity=err&var-query=line%20616%20of%20%2Fsrv%2Fwww%2Fygtc_github%2Freleases%2F20220829084716%2Fdocroot%2Fmodules%2Fcontrib%2Fopeny_repeat%2Fsrc%2FController%2FRepeatController.php

![image](https://user-images.githubusercontent.com/563412/187638657-66911161-8814-46a8-8c18-35217c7b54ed.png)
