### PR TITLE
fix: DS-856 Activity finder modal links not focus visible

### DIFF
--- a/templates/openy-repeat-schedule-dashboard--table.html.twig
+++ b/templates/openy-repeat-schedule-dashboard--table.html.twig
@@ -54,7 +54,7 @@
                 <div class="class-column" v-cloak>
                   <strong><a class="schedule-dashboard__modal--class-link" role="button"
                              v-on:click="$parent.populatePopupClass(item.nid)" data-toggle="modal"
-                             data-target=".schedule-dashboard__modal--class">${ item.name }</a></strong>
+                             data-target=".schedule-dashboard__modal--class" tabindex="0">${ item.name }</a></strong>
                   <p><span>${ item.category }</span></p>
                 </div>
               </div>
@@ -63,7 +63,7 @@
                 <div v-cloak class="location-column">
                   <strong><a class="hidden-xs schedule-dashboard__modal--location-link" role="button"
                              v-on:click="$parent.populatePopupLocation(index)" data-toggle="modal"
-                             data-target=".schedule-dashboard__modal--location">${ item.location }</a>
+                             data-target=".schedule-dashboard__modal--location" tabindex="0">${ item.location }</a>
                     <p class="hidden-md hidden-sm hidden-lg">${ item.location }</p>
                   </strong>
                   <p><span v-if="item.room">${ item.room }</span></p>
@@ -75,8 +75,8 @@
                 {# instructor #}
                 <div v-cloak class="instructor-column">
                   <a class="schedule-dashboard__modal--instructor-link" role="button"
-                     v-on:click="$parent.populatePopupInstructor(item.instructor)" data-toggle="modal"
-                     data-target=".schedule-dashboard__modal--instructor">${ item.instructor }</a>
+                     v-on:click="$parent.populatePopupInstructor(item.instructor)" v-if="item.instructor" data-toggle="modal"
+                     data-target=".schedule-dashboard__modal--instructor" tabindex="0">${ item.instructor }</a>
                 </div>
               </div>
 


### PR DESCRIPTION
- `a` tags without `href` do not get keyboard focus, so they need to have a `tabindex` set
- if instructor field is empty then we have an empty field to tab through. This stops it from rendering if the field is empty.

Source ticket: [DS-856](https://yusa.atlassian.net/browse/DS-856)
Related work: https://git.drupalcode.org/project/openy_carnation/-/merge_requests/68/diffs?commit_id=082a18fdd6da216e551cf3ae2fe3014781a40e8b