### PR TITLE
fix: DS-856 Replace data-toggle with href for keyboard accessibility

### DIFF
--- a/templates/openy-repeat-schedule-dashboard--table.html.twig
+++ b/templates/openy-repeat-schedule-dashboard--table.html.twig
@@ -54,7 +54,7 @@
                 <div class="class-column" v-cloak>
                   <strong><a class="schedule-dashboard__modal--class-link" role="button"
                              v-on:click="$parent.populatePopupClass(item.nid)" data-toggle="modal"
-                             data-target=".schedule-dashboard__modal--class" tabindex="0">${ item.name }</a></strong>
+                             href=".schedule-dashboard__modal--class">${ item.name }</a></strong>
                   <p><span>${ item.category }</span></p>
                 </div>
               </div>
@@ -63,7 +63,7 @@
                 <div v-cloak class="location-column">
                   <strong><a class="hidden-xs schedule-dashboard__modal--location-link" role="button"
                              v-on:click="$parent.populatePopupLocation(index)" data-toggle="modal"
-                             data-target=".schedule-dashboard__modal--location" tabindex="0">${ item.location }</a>
+                             href=".schedule-dashboard__modal--location">${ item.location }</a>
                     <p class="hidden-md hidden-sm hidden-lg">${ item.location }</p>
                   </strong>
                   <p><span v-if="item.room">${ item.room }</span></p>
@@ -76,7 +76,7 @@
                 <div v-cloak class="instructor-column">
                   <a class="schedule-dashboard__modal--instructor-link" role="button"
                      v-on:click="$parent.populatePopupInstructor(item.instructor)" v-if="item.instructor" data-toggle="modal"
-                     data-target=".schedule-dashboard__modal--instructor" tabindex="0">${ item.instructor }</a>
+                     href=".schedule-dashboard__modal--instructor">${ item.instructor }</a>
                 </div>
               </div>
 
@@ -291,7 +291,7 @@
               <div v-cloak class="instructor-column">
                 <a class="schedule-dashboard__modal--instructor-link" role="button"
                    v-on:click="populatePopupInstructor(item.instructor)" data-toggle="modal"
-                   data-target=".schedule-dashboard__modal--instructor">${ item.instructor }</a>
+                   href=".schedule-dashboard__modal--instructor">${ item.instructor }</a>
               </div>
             </div>
 
@@ -390,7 +390,7 @@
               <div class="class-column" v-cloak>
                 <strong><a class="schedule-dashboard__modal--class-link" role="button"
                            v-on:click="populatePopupClass(item.nid)" data-toggle="modal"
-                           data-target=".schedule-dashboard__modal--class">${ item.name }</a></strong>
+                           href=".schedule-dashboard__modal--class">${ item.name }</a></strong>
                 <p><span>${ item.category }</span></p>
               </div>
             </div>
@@ -422,7 +422,7 @@
               <div class="class-column" v-cloak>
                 <strong><a class="schedule-dashboard__modal--class-link" role="button"
                            v-on:click="populatePopupClass(item.nid)" data-toggle="modal"
-                           data-target=".schedule-dashboard__modal--class">${ item.name }</a></strong>
+                           href=".schedule-dashboard__modal--class">${ item.name }</a></strong>
                 <p><span>${ item.category }</span></p>
               </div>
             </div>


### PR DESCRIPTION
As per https://getbootstrap.com/docs/4.6/components/modal/#via-data-attributes, either `data-target` or `href` can be used to trigger a modal. Since we're using `a` as the trigger, changing to `href` will add keyboard accessibility by default, remove the need for `tabindex`, and retain click behavior.