### PR TITLE
Resolve deprecated php warnings.

### DIFF
--- a/src/Controller/RepeatController.php
+++ b/src/Controller/RepeatController.php
@@ -455,11 +455,16 @@ class RepeatController extends ControllerBase {
         if (!empty($classes)) {
           /** @var \Drupal\node\Entity\Node $node */
           foreach ($classes as $node) {
+            $description = '';
+            if (!$node->field_class_description->isEmpty()) {
+              $description = html_entity_decode(strip_tags(text_summary($node->field_class_description->value, $node->field_class_description->format, 600)));
+            }
+
             $data[$node->nid->value] = [
               'nid' => $node->nid->value,
               'path' => $node->toUrl()->setAbsolute()->toString(),
               'title' => $node->title->value,
-              'description' => html_entity_decode(strip_tags(text_summary($node->field_class_description->value, $node->field_class_description->format, 600))),
+              'description' => $description,
             ];
             $tags[] = 'node:' . $node->nid->value;
           }

--- a/src/Controller/RepeatController.php
+++ b/src/Controller/RepeatController.php
@@ -638,12 +638,16 @@ class RepeatController extends ControllerBase {
 
     foreach ($result as $day => $data) {
       foreach ($data as $session) {
-        $words = explode(' ', $session->instructor);
-        $short_name = $words[0];
-        if (isset($words[1])) {
-          $short_name .= ' ' . substr($words[1], 0, 1);
+        $short_name = '';
+        if (!empty($session->instructor)) {
+          $words = explode(' ', $session->instructor);
+          $short_name = $words[0];
+          if (isset($words[1])) {
+            $short_name .= ' ' . substr($words[1], 0, 1);
+          }
+          $short_name = !empty($words[1]) ? $short_name . '.' : $short_name;
         }
-        $short_name = !empty($words[1]) ? $short_name . '.' : $short_name;
+
         $formatted_result['content'][$session->location][$session->name . $session->room]['dates'][$day][] = [
           'time' => $session->time_start . '-' . $session->time_end,
           'category' => $session->category,


### PR DESCRIPTION
Sometimes the class doesn't have a description, thus producing warnings like:

```
Deprecated function: strip_tags(): Passing null to parameter #1 ($string) of type string is deprecated in Drupal\openy_repeat\Controller\RepeatController->getClassesInfo() (line 469 of /app/docroot/modules/contrib/openy_repeat/src/Controller/RepeatController.php)
#0 /app/docroot/core/includes/bootstrap.inc(347): _drupal_error_handler_real(8192, 'strip_tags(): P...', '/app/docroot/mo...', 469)
#1 [internal function]: _drupal_error_handler(8192, 'strip_tags(): P...', '/app/docroot/mo...', 469)
#2 /app/docroot/modules/contrib/openy_repeat/src/Controller/RepeatController.php(469): strip_tags(NULL)
#3 /app/docroot/modules/contrib/openy_repeat/src/Controller/RepeatController.php(323): Drupal\openy_repeat\Controller\RepeatController->getClassesInfo(Array)
```

```
Deprecated function: mb_strlen(): Passing null to parameter #1 ($string) of type string is deprecated in text_summary() (line 95 of /app/docroot/core/modules/text/text.module)
#0 /app/docroot/core/includes/bootstrap.inc(347): _drupal_error_handler_real(8192, 'mb_strlen(): Pa...', '/app/docroot/co...', 95)
#1 [internal function]: _drupal_error_handler(8192, 'mb_strlen(): Pa...', '/app/docroot/co...', 95)
#2 /app/docroot/core/modules/text/text.module(95): mb_strlen(NULL)
#3 /app/docroot/modules/contrib/openy_repeat/src/Controller/RepeatController.php(469): text_summary(NULL, NULL, 600)
#4 /app/docroot/modules/contrib/openy_repeat/src/Controller/RepeatController.php(323): Drupal\openy_repeat\Controller\RepeatController->getClassesInfo(Array)
```

```
Deprecated function: strpos(): Passing null to parameter #1 ($haystack) of type string is deprecated in text_summary() (line 71 of /app/docroot/core/modules/text/text.module)
#0 /app/docroot/core/includes/bootstrap.inc(347): _drupal_error_handler_real(8192, 'strpos(): Passi...', '/app/docroot/co...', 71)
#1 [internal function]: _drupal_error_handler(8192, 'strpos(): Passi...', '/app/docroot/co...', 71)
#2 /app/docroot/core/modules/text/text.module(71): strpos(NULL, '<!--break-->')
#3 /app/docroot/modules/contrib/openy_repeat/src/Controller/RepeatController.php(469): text_summary(NULL, NULL, 600)
#4 /app/docroot/modules/contrib/openy_repeat/src/Controller/RepeatController.php(323): Drupal\openy_repeat\Controller\RepeatController->getClassesInfo(Array)
```

Let's make sure we apply the transformation only when the value for the field is not empty.

Second commit aims to resolve:
```
Deprecated function: explode(): Passing null to parameter #2 ($string) of type string is deprecated in Drupal\openy_repeat\Controller\RepeatController->groupByActivity() (line 648 of /app/docroot/modules/contrib/openy_repeat/src/Controller/RepeatController.php)
#0 /app/docroot/core/includes/bootstrap.inc(347): _drupal_error_handler_real(8192, 'explode(): Pass...', '/app/docroot/mo...', 648)
#1 [internal function]: _drupal_error_handler(8192, 'explode(): Pass...', '/app/docroot/mo...', 648)
#2 /app/docroot/modules/contrib/openy_repeat/src/Controller/RepeatController.php(648): explode(' ', NULL)
#3 /app/docroot/modules/contrib/openy_repeat/src/Controller/RepeatController.php(571): Drupal\openy_repeat\Controller\RepeatController->groupByActivity(Array, '', 0, 0, Array)
```
This happens when there's no instructor information.