### PR TITLE
#40: Don't require nodes to have children

### DIFF
--- a/modules/openy_repeat_nodes/openy_repeat_nodes.module
+++ b/modules/openy_repeat_nodes/openy_repeat_nodes.module
@@ -85,6 +85,9 @@ function openy_repeat_nodes_actualize_sessions(EntityInterface $entity) {
         ->condition('field_activity_category', $entity_ids, 'IN')
         ->accessCheck(FALSE)
         ->execute();
+      if (!$entity_ids) {
+        return;
+      }
       $bundle = 'activity';
     }
 
@@ -94,6 +97,9 @@ function openy_repeat_nodes_actualize_sessions(EntityInterface $entity) {
         ->condition('field_class_activity', $entity_ids, 'IN')
         ->accessCheck(FALSE)
         ->execute();
+      if (!$entity_ids) {
+        return;
+      }
       $bundle = 'class';
     }
 


### PR DESCRIPTION
Currently for example if you have an activity with no child class nodes, it can cause a fatal error when updating the activity node.

Closes #40