### PR TITLE
DS-1479: Placeholder of the Schedules block isn't visible

### DIFF
--- a/css/repeat.css
+++ b/css/repeat.css
@@ -465,13 +465,13 @@ body.modal-open .top-navs .nav-global {
 }
 
 /*Modal view for instructor*/
-.modal-dialog {
+.modal-dialog:not(.hb-loc-modal__modal) {
     height: 80% !important;
     padding-top: 10%;
     top: 20vh;
 }
 
-.modal-content {
+.modal-dialog:not(.hb-loc-modal__modal) .modal-content {
     height: 100% !important;
     overflow: visible;
     bottom: 5vh;
@@ -896,4 +896,10 @@ body.modal-open .top-navs .nav-global {
 
 .pr-none {
     padding-right: 0 !important;
+}
+
+.block-inline-blocklb-repeat-schedules a.btn {
+  padding: 10px 12px 6px;
+  font-size: 16px;
+  line-height: 24px;
 }

--- a/modules/lb_repeat_schedules/lb_repeat_schedules.module
+++ b/modules/lb_repeat_schedules/lb_repeat_schedules.module
@@ -1,0 +1,23 @@
+<?php
+
+
+/**
+ * Implements hook_theme().
+ */
+function lb_repeat_schedules_theme() {
+  return [
+    'block__inline_block__lb_repeat_schedules' => [
+      'base hook' => 'block',
+      'template' => 'block--inline-block--lb-repeat-schedules',
+    ],
+  ];
+}
+
+/**
+ * Implements hook_preprocess_HOOK().
+ */
+function lb_repeat_schedules_preprocess_block__inline_block__lb_repeat_schedules(&$variables) {
+  if ($variables['in_preview']) {
+    $variables['in_preview_placeholder'] = t('Repeat Schedules: To see your changes in this block, please save the layout.');
+  }
+}

--- a/modules/lb_repeat_schedules/templates/block--inline-block--lb-repeat-schedules.html.twig
+++ b/modules/lb_repeat_schedules/templates/block--inline-block--lb-repeat-schedules.html.twig
@@ -1,0 +1,43 @@
+{#
+/**
+ * @file
+ * Default theme implementation to display a block.
+ *
+ * Available variables:
+ * - plugin_id: The ID of the block implementation.
+ * - label: The configured label of the block if visible.
+ * - configuration: A list of the block's configuration values.
+ *   - label: The configured label for the block.
+ *   - label_display: The display settings for the label.
+ *   - provider: The module or other provider that provided this block plugin.
+ *   - Block plugin specific settings will also be stored here.
+ * - content: The content of this block.
+ * - attributes: array of HTML attributes populated by modules, intended to
+ *   be added to the main container tag of this template.
+ *   - id: A valid HTML ID and guaranteed unique.
+ * - title_attributes: Same as attributes, except applied to the main title
+ *   tag that appears in the template.
+ * - title_prefix: Additional output populated by modules, intended to be
+ *   displayed in front of the main title tag that appears in the template.
+ * - title_suffix: Additional output populated by modules, intended to be
+ *   displayed after the main title tag that appears in the template.
+ *
+ * @see template_preprocess_block()
+ *
+ * @ingroup themeable
+ */
+#}
+<div{{ attributes }}>
+  {{ title_prefix }}
+  {% if label %}
+    <h2{{ title_attributes }}>{{ label }}</h2>
+  {% endif %}
+  {{ title_suffix }}
+  {% block content %}
+    {% if in_preview %}
+      {{ in_preview_placeholder }}
+    {% else %}
+      {{ content }}
+    {% endif %}
+  {% endblock %}
+</div>

--- a/openy_repeat.libraries.yml
+++ b/openy_repeat.libraries.yml
@@ -1,5 +1,5 @@
 openy_repeat:
-  version: 0.3.4
+  version: 0.3.5
   js:
     js/repeat.js: {}
   css:


### PR DESCRIPTION
Issues:
https://yusa.atlassian.net/browse/DS-1479
https://yusa.atlassian.net/browse/DS-1481
https://yusa.atlassian.net/browse/DS-1480

- log in as admin
- Enable the module "Y Layout Builder - Repeat Schedules"
- Create a new Landing Page (Layout Builder)
- Click to "Add a block" to a section
- Add the block called "Repeat (Group) Schedules"
- Configure as you would configure the Repeat Schedules paragraph in the old Landing Page approach
- Ensure that Titles are not cropped
- Add the block
- Check Placeholder isn’t displayed
- Save the Landing Page (Layout Builder)
- Check the page
- Check the Register button