### PR TITLE
DS-1484: The user can't close Filters section on the Schedules page 

### DIFF
--- a/css/repeat.css
+++ b/css/repeat.css
@@ -879,7 +879,7 @@ body.modal-open .top-navs .nav-global {
     box-shadow: none;
 }
 
-@media screen and (min-width: 992px) {
+@media screen and (min-width: 1060px) {
     .schedules-filters {
         display: block !important;
     }

--- a/css/repeat_mobile.css
+++ b/css/repeat_mobile.css
@@ -6,7 +6,7 @@
   .schedule-dashboard__modal .modal-dialog {
     max-width: 100%;
   }
-  .modal-dialog {
+  .modal-dialog:not(.hb-loc-modal__modal){
     top: 15px;
     height: 100% !important;
     padding-top: 35px !important;
@@ -166,7 +166,7 @@
 }
 
 @media (max-width: 540px) {
-  .modal-dialog {
+  .modal-dialog:not(.hb-loc-modal__modal) {
     padding-right: 15px !important;
   }
 }

--- a/openy_repeat.libraries.yml
+++ b/openy_repeat.libraries.yml
@@ -1,5 +1,5 @@
 openy_repeat:
-  version: 0.3.5
+  version: 0.3.6
   js:
     js/repeat.js: {}
   css:


### PR DESCRIPTION
https://yusa.atlassian.net/browse/DS-1484

Step to review

- log in as admin
- Enable the module "Y Layout Builder - Repeat Schedules"
- Create a new Landing Page (Layout Builder)
- Click to "Add a block" to a section
- Add the block called "Repeat (Group) Schedules"
- Configure as you would configure the Repeat Schedules paragraph in the old Landing Page approach
- Add the block
- Save the Landing Page (Layout Builder)
- open the page on the tablet
- click on the Refine results accordion 