### PR TITLE
[#64] Fix incorrect location info in popup

### DIFF
--- a/js/repeat/src/repeat.js
+++ b/js/repeat/src/repeat.js
@@ -521,7 +521,7 @@ Vue.use(VueRouter);
       },
       populatePopupLocation: function (index) {
         $('.modal').modal('hide');
-        this.locationPopup = this.filteredTable[index].location_info;
+        this.locationPopup = this.pagedTable[index].location_info;
       },
       populatePopupClass: function (sessionId) {
         var component = this;


### PR DESCRIPTION
Hi @podarok 
A fix for the issue https://github.com/ynorth-projects/openy_repeat/issues/64

**The method that opens the popup for the Location uses the index line on the current page:**
![2024-09-02_19-52](https://github.com/user-attachments/assets/cfdc17b2-365c-49ed-b5de-848da921316f)

**And it returns data from an array of all results, ignoring page pagination:**
![2024-09-02_19-56](https://github.com/user-attachments/assets/ec48fcf4-8e6b-47f8-94d2-7dad20d3da62)

**To display correctly, you need to use the results data of the current page:**
![2024-09-02_20-00](https://github.com/user-attachments/assets/f5dd68cd-267c-45af-b7ff-ae1430421fee)


