### PR TITLE
Fix deprecation and undefined array key

### DIFF
--- a/src/Controller/RepeatController.php
+++ b/src/Controller/RepeatController.php
@@ -546,8 +546,8 @@ class RepeatController extends ControllerBase {
       'body' => [
         '#content' => [
           'logo_url' => \Drupal::service('extension.list.module')->getPath('openy_repeat') . '/img/ymca_logo_black.png',
-          'result' => $content['content']['content'],
-          'header' => $content['content']['header'],
+          'result' => $content['content']['content'] ?? [],
+          'header' => $content['content']['header'] ?? [],
         ],
         '#theme' => $content['theme'],
         '#cache' => [

--- a/src/OpenyRepeatRepository.php
+++ b/src/OpenyRepeatRepository.php
@@ -40,6 +40,11 @@ class OpenyRepeatRepository implements OpenyRepeatRepositoryInterface {
   protected $nodeStorage;
 
   /**
+   * @var \Drupal\Core\Cache\MemoryCache\MemoryCacheInterface
+   */
+  private MemoryCacheInterface $memoryCache;
+
+  /**
    * Constructs a OpenyRepeatRepository object.
    *
    * @param \Drupal\Core\Entity\EntityTypeManager $entity_type_manager


### PR DESCRIPTION
This resolves two issues:

1. When loading `get-pdf`, a "creation of dynamic property" warning.
    > Deprecated function: Creation of dynamic property Drupal\openy_repeat\OpenyRepeatRepository::$memoryCache is deprecated in Drupal\openy_repeat\OpenyRepeatRepository->__construct() (line 62 of /var/www/html/docroot/modules/contrib/openy_repeat/src/OpenyRepeatRepository.php)

2. When loading an empty PDF, an "undefined array" warning:
    > Warning: Undefined array key "content" in Drupal\openy_repeat\Controller\RepeatController->getPdf() (line 549 of /var/www/html/docroot/modules/contrib/openy_repeat/src/Controller/RepeatController.php)
